### PR TITLE
Fix Nix build

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -85,9 +85,9 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "cast"
-version = "0.2.3"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b9434b9a5aa1450faa3f9cb14ea0e8c53bb5d2b3c1bfd1ab4fc03e9f33fbfb0"
+checksum = "cc38c385bfd7e444464011bb24820f40dd1c76bcdfa1b78611cb7c2e5cafab75"
 dependencies = [
  "rustc_version",
 ]
@@ -688,7 +688,7 @@ dependencies = [
 [[package]]
 name = "rayon-cond"
 version = "0.1.0"
-source = "git+https://github.com/n1t0/rayon-cond#c56e4f1ded0fcb92eac70e0533703bba3ca2983f"
+source = "git+https://github.com/n1t0/rayon-cond?rev=c56e4f1ded0fcb92eac70e0533703bba3ca2983f#c56e4f1ded0fcb92eac70e0533703bba3ca2983f"
 dependencies = [
  "either",
  "itertools 0.8.2",

--- a/nix/rust.nix
+++ b/nix/rust.nix
@@ -12,7 +12,7 @@ let
       install_name_tool -id $out/lib/libtokenizers_haskell.dylib $out/lib/libtokenizers_haskell.dylib
     ''
     else ''
-      patchelf --set-rpath "${rpath}:$out/lib" $out/lib/libtokenizers_haskell.so
+      patchelf --set-rpath "$out/lib" $out/lib/libtokenizers_haskell.so
     '';
 
   self = {

--- a/nix/rust.nix
+++ b/nix/rust.nix
@@ -12,7 +12,7 @@ let
       install_name_tool -id $out/lib/libtokenizers_haskell.dylib $out/lib/libtokenizers_haskell.dylib
     ''
     else ''
-      patchelf --set-rpath "$out/lib" $out/lib/libtokenizers_haskell.so
+      patchelf --set-rpath "${stdenv.cc.cc.lib}/lib:$out/lib" $out/lib/libtokenizers_haskell.so
     '';
 
   self = {

--- a/tokenizers/Cargo.toml
+++ b/tokenizers/Cargo.toml
@@ -40,7 +40,7 @@ onig = { version = "6.0", default-features = false }
 regex = "1.3"
 regex-syntax = "0.6"
 rayon = "1.3"
-rayon-cond = { version = "*", git = "https://github.com/n1t0/rayon-cond" }
+rayon-cond = { version = "*", git = "https://github.com/n1t0/rayon-cond", rev = "c56e4f1ded0fcb92eac70e0533703bba3ca2983f" }
 serde = { version = "1.0", features = [ "derive" ] }
 serde_json = "1.0"
 clap = "2.33"


### PR DESCRIPTION
On non-Darwin platforms nix/rust.nix throws an error: variable `rpath` is undefined. I fixed it by changing the undefined variable to `stdenv.cc.cc.lib`. Without it the binary cannot find `libstdc++.so.6` library:
```console
# Without stdenv.cc.cc.lib
$ ldd ./result/lib/libtokenizers_haskell.so
		linux-vdso.so.1 (0x00007ffcec587000)
        libstdc++.so.6 => not found
        libgcc_s.so.1 => /nix/store/v8q6nxyppy1myi3rxni2080bv8s9jxiy-glibc-2.32-40/lib/libgcc_s.so.1 (0x00007fe3141aa000)
        libpthread.so.0 => /nix/store/v8q6nxyppy1myi3rxni2080bv8s9jxiy-glibc-2.32-40/lib/libpthread.so.0 (0x00007fe314189000)
        libm.so.6 => /nix/store/v8q6nxyppy1myi3rxni2080bv8s9jxiy-glibc-2.32-40/lib/libm.so.6 (0x00007fe314046000)
        libdl.so.2 => /nix/store/v8q6nxyppy1myi3rxni2080bv8s9jxiy-glibc-2.32-40/lib/libdl.so.2 (0x00007fe314041000)
        libc.so.6 => /nix/store/v8q6nxyppy1myi3rxni2080bv8s9jxiy-glibc-2.32-40/lib/libc.so.6 (0x00007fe313e80000)
        /nix/store/v8q6nxyppy1myi3rxni2080bv8s9jxiy-glibc-2.32-40/lib64/ld-linux-x86-64.so.2 (0x00007fe314579000)

# With stdenv.cc.cc.lib
$ ldd ./result/lib/libtokenizers_haskell.so
		linux-vdso.so.1 (0x00007ffe0a5eb000)
        libstdc++.so.6 => /nix/store/sipmc4wnbcws4vahqlf5i06zz7xgnp23-gcc-10.2.0-lib/lib/libstdc++.so.6 (0x00007f9ca7f80000)
        libgcc_s.so.1 => /nix/store/sipmc4wnbcws4vahqlf5i06zz7xgnp23-gcc-10.2.0-lib/lib/libgcc_s.so.1 (0x00007f9ca7f66000)
        libpthread.so.0 => /nix/store/v8q6nxyppy1myi3rxni2080bv8s9jxiy-glibc-2.32-40/lib/libpthread.so.0 (0x00007f9ca7f45000)
        libm.so.6 => /nix/store/v8q6nxyppy1myi3rxni2080bv8s9jxiy-glibc-2.32-40/lib/libm.so.6 (0x00007f9ca7e02000)
        libdl.so.2 => /nix/store/v8q6nxyppy1myi3rxni2080bv8s9jxiy-glibc-2.32-40/lib/libdl.so.2 (0x00007f9ca7dfd000)
        libc.so.6 => /nix/store/v8q6nxyppy1myi3rxni2080bv8s9jxiy-glibc-2.32-40/lib/libc.so.6 (0x00007f9ca7c3a000)
        /nix/store/v8q6nxyppy1myi3rxni2080bv8s9jxiy-glibc-2.32-40/lib64/ld-linux-x86-64.so.2 (0x00007f9ca850a000)
```

I also added a revision tag to `rayon-cond` dependency, because Naersk refused to fetch it for me.